### PR TITLE
Fix callback calls

### DIFF
--- a/THTinderNavigationController/THTinderNavigationController.m
+++ b/THTinderNavigationController/THTinderNavigationController.m
@@ -242,7 +242,8 @@ typedef NS_ENUM(NSInteger, THSlideType) {
 
 - (void)callBackChangedPage {
     if (self.didChangedPageCompleted) {
-        self.didChangedPageCompleted(self.currentPage, [[self.paggedViewControllers valueForKey:@"title"] objectAtIndex:self.currentPage]);
+        UIViewController *currentViewController = self.paggedViewControllers[self.currentPage];
+        self.didChangedPageCompleted(self.currentPage, currentViewController.title);
     }
 }
 


### PR DESCRIPTION
In Swift this cause exception, because it's trying to call `length` method form `NSNull`

When you use `valueForKey:` method on `NSArray`, it returns new array: result of invoking selector "title".
But whenever viewController's title equals `nil`, there will be `NSNull` object.
